### PR TITLE
flash: lazy-load ES6 modules with babel require hook

### DIFF
--- a/build/actions/flash.js
+++ b/build/actions/flash.js
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Promise, _, chalk, drivelist, form, fs, imageWrite, os, umount, visuals;
+var Promise, _, chalk, drivelist, form, fs, os, umount, visuals;
 
 _ = require('lodash');
 
@@ -33,8 +33,6 @@ chalk = require('chalk');
 visuals = require('resin-cli-visuals');
 
 form = require('resin-cli-form');
-
-imageWrite = require('etcher-image-write');
 
 module.exports = {
   signature: 'flash <image>',
@@ -55,6 +53,12 @@ module.exports = {
     }
   ],
   action: function(params, options, done) {
+    var imageWrite;
+    require('babel-register')({
+      only: /etcher-image-write|bmapflash/,
+      presets: ["es2015"]
+    });
+    imageWrite = require('etcher-image-write');
     return form.run([
       {
         message: 'Select drive',

--- a/lib/actions/flash.coffee
+++ b/lib/actions/flash.coffee
@@ -23,7 +23,6 @@ drivelist = Promise.promisifyAll(require('drivelist'))
 chalk = require('chalk')
 visuals = require('resin-cli-visuals')
 form = require('resin-cli-form')
-imageWrite = require('etcher-image-write')
 
 module.exports =
 	signature: 'flash <image>'
@@ -50,6 +49,14 @@ module.exports =
 			alias: 'd'
 	]
 	action: (params, options, done) ->
+
+		# XXX: Find a better ES6 module loading story/contract between resin.io modules
+		require('babel-register')({
+			only: /etcher-image-write|bmapflash/
+			presets: ["es2015"]
+		})
+		imageWrite = require('etcher-image-write')
+
 		form.run [
 			{
 				message: 'Select drive'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "resin-lint": "^1.4.0"
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.16.0",
+    "babel-register": "^6.16.3",
     "bluebird": "^3.4.6",
     "capitano": "^1.7.4",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Connects to #16 

Hotfix, until we have a better story/contract for resin.io ES6 modules.