### PR TITLE
Implement scan

### DIFF
--- a/build/actions/index.js
+++ b/build/actions/index.js
@@ -20,6 +20,7 @@ module.exports = {
   sync: require('./sync'),
   ssh: require('./ssh'),
   logs: require('./logs'),
+  scan: require('./scan'),
   configure: require('./configure'),
   flash: require('./flash')
 };

--- a/build/actions/scan.js
+++ b/build/actions/scan.js
@@ -1,0 +1,88 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+var dockerInfoProperties, dockerVersionProperties;
+
+dockerInfoProperties = ['Containers', 'ContainersRunning', 'ContainersPaused', 'ContainersStopped', 'Images', 'Driver', 'SystemTime', 'KernelVersion', 'OperatingSystem', 'Architecture'];
+
+dockerVersionProperties = ['Version', 'ApiVersion'];
+
+module.exports = {
+  signature: 'scan',
+  description: 'Scan for resinOS devices in your local network',
+  help: '\nExamples:\n\n	$ rdt scan\n	$ rdt scan --verbose',
+  primary: true,
+  options: [
+    {
+      signature: 'verbose',
+      boolean: true,
+      description: 'Display full info',
+      alias: 'v'
+    }
+  ],
+  action: function(params, options, done) {
+    var Docker, Promise, SpinnerPromise, _, discover, prettyjson;
+    Promise = require('bluebird');
+    _ = require('lodash');
+    prettyjson = require('prettyjson');
+    Docker = require('docker-toolbelt');
+    discover = require('resin-sync').discover;
+    SpinnerPromise = require('resin-cli-visuals').SpinnerPromise;
+    return Promise["try"](function() {
+      return new SpinnerPromise({
+        promise: discover.discoverLocalResinOsDevices(),
+        startMessage: 'Scanning for local resinOS devices..',
+        stopMessage: 'Reporting scan results'
+      });
+    }).tap(function(devices) {
+      if (_.isEmpty(devices)) {
+        throw new Error('Could not find any resinOS devices in the local network');
+      }
+    }).map(function(arg) {
+      var address, docker, host;
+      host = arg.host, address = arg.address;
+      docker = new Docker({
+        host: address,
+        port: 2375
+      });
+      return Promise.props({
+        dockerInfo: docker.infoAsync().catchReturn('Could not get Docker info'),
+        dockerVersion: docker.versionAsync().catchReturn('Could not get Docker version')
+      }).then(function(arg1) {
+        var dockerInfo, dockerVersion;
+        dockerInfo = arg1.dockerInfo, dockerVersion = arg1.dockerVersion;
+        if (!options.verbose) {
+          if (_.isObject(dockerInfo)) {
+            dockerInfo = _.pick(dockerInfo, dockerInfoProperties);
+          }
+          if (_.isObject(dockerVersion)) {
+            dockerVersion = _.pick(dockerVersion, dockerVersionProperties);
+          }
+        }
+        return {
+          host: host,
+          address: address,
+          dockerInfo: dockerInfo,
+          dockerVersion: dockerVersion
+        };
+      });
+    }).then(function(devicesInfo) {
+      return console.log(prettyjson.render(devicesInfo, {
+        noColor: true
+      }));
+    }).nodeify(done);
+  }
+};

--- a/build/app.js
+++ b/build/app.js
@@ -45,6 +45,8 @@ capitano.command(actions.sync);
 
 capitano.command(actions.logs);
 
+capitano.command(actions.scan);
+
 capitano.command(actions.configure);
 
 capitano.command(actions.flash);

--- a/lib/actions/index.coffee
+++ b/lib/actions/index.coffee
@@ -20,5 +20,6 @@ module.exports =
 	sync: require('./sync')
 	ssh: require('./ssh')
 	logs: require('./logs')
+	scan: require('./scan')
 	configure: require('./configure')
 	flash: require('./flash')

--- a/lib/actions/scan.coffee
+++ b/lib/actions/scan.coffee
@@ -56,29 +56,13 @@ module.exports =
 		prettyjson = require('prettyjson')
 		Docker = require('docker-toolbelt')
 		{ discover } = require('resin-sync')
-		{ Spinner } = require('resin-cli-visuals')
-
-		# XXX: import this function from `resin-cli-visuals` when PR is merged
-		spinnerPromise = Promise.method (promise, startMsg, stopMsg) ->
-
-			clearSpinner = (spinner, msg) ->
-				spinner.stop() if spinner?
-				console.log(msg) if msg?
-
-			spinner = new Spinner(startMsg)
-			spinner.start()
-			promise.tap (value) ->
-				clearSpinner(spinner, stopMsg)
-			.catch (err) ->
-				clearSpinner(spinner)
-				throw err
+		{ SpinnerPromise } = require('resin-cli-visuals')
 
 		Promise.try ->
-			spinnerPromise(
-				discover.discoverLocalResinOsDevices()
-				'Scanning for local resinOS devices..'
-				'Reporting scan results'
-			)
+			new SpinnerPromise
+				promise: discover.discoverLocalResinOsDevices()
+				startMessage: 'Scanning for local resinOS devices..'
+				stopMessage: 'Reporting scan results'
 		.tap (devices) ->
 			if _.isEmpty(devices)
 				throw new Error('Could not find any resinOS devices in the local network')

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -34,9 +34,12 @@ capitano.command(actions.ssh)
 
 # ---------- Sync Module ----------
 capitano.command(actions.sync)
-#
+
 # ---------- Logs Module ----------
 capitano.command(actions.logs)
+
+# ---------- Scan Module ----------
+capitano.command(actions.scan)
 
 # ---------- Configuration Module ----------
 capitano.command(actions.configure)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "inquirer": "^1.2.1",
     "is-root": "^1.0.0",
     "lodash": "^4.16.2",
+    "prettyjson": "^1.1.3",
     "reconfix": "0.0.3",
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",


### PR DESCRIPTION
#### Description:

```
kostasl@macbook:~/resin/github/resin-os/resin-device-toolbox$ ./bin/resin-device-toolbox scan -h
Usage: scan


Examples:

	$ rdt scan
	$ rdt scan --verbose

Options:

    --verbose, -v                       Display full info  
```

#### Preview:

```
kostasl@macbook:~/resin/github/resin-os/resin-device-toolbox$ ./bin/resin-device-toolbox scan 
| Scanning for local resinOS devices..
Reporting scan results
- 
  host:          resinos-beta.local
  address:       192.168.1.10
  dockerInfo: 
    Containers:        5
    ContainersRunning: 5
    ContainersPaused:  0
    ContainersStopped: 0
    Images:            21
    Driver:            aufs
    SystemTime:        2016-10-13T16:57:26.991495101Z
    KernelVersion:     4.1.21
    OperatingSystem:   Resin OS 2.0.0-beta.1
    Architecture:      armv7l
  dockerVersion: 
    Version:    1.10.3
    ApiVersion: 1.22
```

Closes #13 