### PR TITLE
Bump to resin-sync@6.0.0

### DIFF
--- a/lib/actions/logs.coffee
+++ b/lib/actions/logs.coffee
@@ -47,12 +47,12 @@ module.exports =
 	]
 	action: (params, options, done) ->
 		Promise = require('bluebird')
-		{ discover } = require('resin-sync')
+		{ forms } = require('resin-sync')
 		{ common } = require('../utils')
 
 		Promise.try ->
 			if not params.deviceIp?
-				return discover.selectLocalResinOsDeviceForm()
+				return forms.selectLocalResinOsDevice()
 			return params.deviceIp
 		.then (@deviceIp) =>
 			if not options['app-name']?

--- a/lib/actions/scan.coffee
+++ b/lib/actions/scan.coffee
@@ -55,12 +55,12 @@ module.exports =
 		_ = require('lodash')
 		prettyjson = require('prettyjson')
 		Docker = require('docker-toolbelt')
-		{ discover } = require('resin-sync')
+		{ forms } = require('resin-sync')
 		{ SpinnerPromise } = require('resin-cli-visuals')
 
 		Promise.try ->
 			new SpinnerPromise
-				promise: discover.discoverLocalResinOsDevices()
+				promise: forms.discoverLocalResinOsDevices()
 				startMessage: 'Scanning for local resinOS devices..'
 				stopMessage: 'Reporting scan results'
 		.tap (devices) ->

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -81,7 +81,7 @@ module.exports =
 		child_process = require('child_process')
 		Promise = require 'bluebird'
 		_ = require('lodash')
-		{ discover } = require('resin-sync')
+		{ forms } = require('resin-sync')
 		{ common } = require('../utils')
 
 		if (options.host is true and options.container?)
@@ -94,7 +94,7 @@ module.exports =
 
 		Promise.try ->
 			if not params.deviceIp?
-				return discover.selectLocalResinOsDeviceForm()
+				return forms.selectLocalResinOsDevice()
 			return params.deviceIp
 		.then (deviceIp) ->
 			_.assign(options, { deviceIp })

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.9",
-    "resin-sync": "^5.0.0",
+    "resin-sync": "^6.0.0",
     "umount": "^1.1.3",
     "underscore.string": "^3.3.4",
     "update-notifier": "^1.0.2"


### PR DESCRIPTION
- [x] Minor code refactor (`discoverLocalResinOsDevices()` method moved
  to `require('resin-sync').forms`)
- [x] Support environment variable setting

Closes #27 
#### rdt push example
---

Multiple environment variables can be passed when building a new container like this:

`rdt push --env "ENV1=value" --env "ENV2=value"`

The passed variables will automatically be saved into `.resin-sync.yml`.
#### .resin-sync.yml example
---

The saved format of the environment variables [resembles the familiar `docker-compose.yml`:](https://docs.docker.com/compose/environment-variables/#/setting-environment-variables-in-containers)

```
local_resinos:
  app-name: myapp
  build-triggers:
    - Dockerfile: 65ee22342bda5adc30f82e62cee62a110d7f354a9c3e1124ad8f69cd579214fa
    - package.json: 1e40740d7cf5018cf887124ee75917eb139d49473c51464580feda247b3a4641
  environment:
    - ENV1=1
    - ENV2=2
```
